### PR TITLE
logging: add rsyslog hub/client templates, logrotate, gzip cron, ngin…

### DIFF
--- a/ansible/templates/logging/cron-corp-gzip-older-than-7d.sh.j2
+++ b/ansible/templates/logging/cron-corp-gzip-older-than-7d.sh.j2
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+find /var/log/corp -type f -name "*-20*.log" -mtime +7 ! -name "*.gz" -exec gzip -f {} \;

--- a/ansible/templates/logging/logrotate-corp-central-logs.j2
+++ b/ansible/templates/logging/logrotate-corp-central-logs.j2
@@ -1,0 +1,14 @@
+/var/log/corp/*/*.log {
+  daily
+  rotate 45
+  missingok
+  notifempty
+  dateext
+  dateformat -%Y%m%d
+  nocompress
+  create 0640 syslog adm
+  sharedscripts
+  postrotate
+    systemctl reload rsyslog >/dev/null 2>&1 || true
+  endscript
+}

--- a/ansible/templates/logging/nginx-log-browse.conf.j2
+++ b/ansible/templates/logging/nginx-log-browse.conf.j2
@@ -1,0 +1,15 @@
+server {
+  listen 80;
+  server_name syslog.corp.local;
+
+  auth_basic "Logs";
+  auth_basic_user_file /etc/nginx/.htpasswd-logs;
+
+  location / {
+    root /var/log/corp;
+    autoindex on;
+    autoindex_exact_size off;
+    autoindex_localtime on;
+    allow 192.168.1.0/24; deny all;
+  }
+}

--- a/ansible/templates/logging/rsyslog-client-99-forward-to-syslog-hub.conf.j2
+++ b/ansible/templates/logging/rsyslog-client-99-forward-to-syslog-hub.conf.j2
@@ -1,0 +1,10 @@
+global(preserveFQDN="on")
+module(load="omfwd")
+
+*.* action(type="omfwd"
+          target="syslog.corp.local"
+          port="514"
+          protocol="tcp"
+          KeepAlive="on"
+          Action.ResumeRetryCount="-1"
+          queue.type="LinkedList" queue.size="10000")

--- a/ansible/templates/logging/rsyslog-hub-00-remote-listener.conf.j2
+++ b/ansible/templates/logging/rsyslog-hub-00-remote-listener.conf.j2
@@ -1,0 +1,14 @@
+global(preserveFQDN="on")
+module(load="imtcp")
+
+template(name="PerHostPkg" type="string"
+         string="/var/log/corp/%hostname%/%syslogfacility-text%.log")
+
+ruleset(name="perHost") {
+  action(type="omfile" dynaFile="PerHostPkg"
+         createDirs="on" dirCreateMode="2770"
+         fileOwner="syslog" fileGroup="adm" fileCreateMode="0640")
+  stop
+}
+
+input(type="imtcp" port="514" ruleset="perHost")


### PR DESCRIPTION
## Why
Stand up a lean, reproducible central logging stack:
- single source of truth on `syslog.corp.local`
- quick, read-only log browsing
- hot→cold separation with nightly archives to HP2

## What changed
Adds Ansible-friendly templates (no secrets):
- `ansible/templates/logging/rsyslog-hub-00-remote-listener.conf.j2`
  - hub listener (TCP 514), per-host/per-facility storage under /var/log/corp/<fqdn>/
  - FQDN preserved for sane folder names
- `ansible/templates/logging/rsyslog-client-99-forward-to-syslog-hub.conf.j2`
  - client forwarder (omfwd over TCP), queue + retry
- `ansible/templates/logging/logrotate-corp-central-logs.j2`
  - daily rotation, 45 copies, reload rsyslog post-rotate
- `ansible/templates/logging/cron-corp-gzip-older-than-7d.sh.j2`
  - gzip rotated logs ≥7d (keeps hot logs uncompressed)
- `ansible/templates/logging/nginx-log-browse.conf.j2`
  - read-only directory listing over `/var/log/corp` with basic auth + LAN allow-list

Docs:
- `docs/logging/architecture.md` (design + runbook pointers)

## How it was verified (manual)
- Hub writes appear under `/var/log/corp/<fqdn>/<facility>.log`
- Nginx prompts for auth and lists folders/files
- HP2 share mounted at `/mnt/hp2-archives` and writable by `syslog:adm`
- Nightly rsync tested (dry run + real) to copy only `*.gz` to HP2

## Rollout notes
- Apply hub template to `syslog.corp.local`; client template to all Linux boxes (RHEL/Rocky/Debian/Ubuntu).
- Install logrotate policy and gzip cron on the hub; enable nginx site + htpasswd.
- Keep HP2 mount in fstab (IP-based) with proper uid/gid.

## Security
- No credentials in repo; nginx uses htpasswd file on host.
- Read-only browse; logs are `0640 syslog:adm`.
- Access limited to 192.168.1.0/24.

## Backout
Revert this commit and restore previous rsyslog/nginx config; logs continue to write locally on clients.

